### PR TITLE
Fix all the links to the reference PDFs

### DIFF
--- a/ecfactory/bn_curves/readme.md
+++ b/ecfactory/bn_curves/readme.md
@@ -4,7 +4,7 @@ Barreto-Naehrig Curves
 Overview
 --------
 
-This module provides functionality to construct _Barreto-Naehrig (BN) curves_, following the procedure described in [\[BN05\]](/references/Barreto Naehrig 2005 --- Pairing-Friendly Elliptic Curves of Prime Order.pdf). The module contains three files:
+This module provides functionality to construct _Barreto-Naehrig (BN) curves_, following the procedure described in [\[BN05\]](/references/Barreto%20Naehrig%202005%20---%20Pairing-Friendly%20Elliptic%20Curves%20of%20Prime%20Order.pdf). The module contains three files:
 
 * `bn_curves.py`, which contains the algorithm to construct Barreto-Naehrig curves;
 

--- a/ecfactory/cocks_pinch/readme.md
+++ b/ecfactory/cocks_pinch/readme.md
@@ -4,7 +4,7 @@ Cocks-Pinch Method
 Overview
 --------
 
-This module provides functionality to construct pairing-friendly elliptic curves via the _Cocks-Pinch (CP) method_; curves constructed via this method have &rho;-value approximately 2. The implementation follows the procedure described in [\[FST10\]](/references/Freeman Scott Teske 2010 --- A Taxonomy of Pairing-Friendly Elliptic Curves.pdf). This module contains three files:
+This module provides functionality to construct pairing-friendly elliptic curves via the _Cocks-Pinch (CP) method_; curves constructed via this method have &rho;-value approximately 2. The implementation follows the procedure described in [\[FST10\]](/references/Freeman%20Scott%20Teske%202010%20---%20A%20Taxonomy%20of%20Pairing-Friendly%20Elliptic%20Curves.pdf). This module contains three files:
 
 * `cocks_pinch.py`, which contains the algorithm for the CP method. 
 

--- a/ecfactory/complex_multiplication/readme.md
+++ b/ecfactory/complex_multiplication/readme.md
@@ -4,7 +4,7 @@ Complex Mulitiplication
 Overview
 --------
 
-This module provides functionality to construct elliptic curves via the _Complex Multiplication (CM) method_. The implementation follows the procedure described in [\[W08\]](/references/Washington 2008 --- Elliptic Curves Number Theory and Cryptography.pdf). This module contains three files:
+This module provides functionality to construct elliptic curves via the _Complex Multiplication (CM) method_. The implementation follows the procedure described in [\[W08\]](/references/Washington%202008%20---%20Elliptic%20Curves%20Number%20Theory%20and%20Cryptography.pdf). This module contains three files:
 
 * `complex_multiplication.py`, which contains the algorithm for the CM method;
 

--- a/ecfactory/dupont_enge_morain/readme.md
+++ b/ecfactory/dupont_enge_morain/readme.md
@@ -4,7 +4,7 @@ Dupont-Enge-Morain Method
 Overview
 --------
 
-This module provides functionality to construct pairing-friendly elliptic curves via the _Dupont-Enge-Morain (DEM) method_; curves constructed via this method have &rho;-value approximately 2. The implementation follows the procedure described in [\[FST10\]](/references/Freeman Scott Teske 2010 --- A Taxonomy of Pairing-Friendly Elliptic Curves.pdf). This module contains three files:
+This module provides functionality to construct pairing-friendly elliptic curves via the _Dupont-Enge-Morain (DEM) method_; curves constructed via this method have &rho;-value approximately 2. The implementation follows the procedure described in [\[FST10\]](/references/Freeman%20Scott%20Teske%202010%20---%20A%20Taxonomy%20of%20Pairing-Friendly%20Elliptic%20Curves.pdf). This module contains three files:
 
 * `dupont_enge_morain.py`, which contains the algorithm that implements the DEM method. 
 

--- a/ecfactory/mnt_curves/readme.md
+++ b/ecfactory/mnt_curves/readme.md
@@ -4,7 +4,7 @@ MNT Curves
 Overview
 --------
 
-This module provides functionality to construct _Miyaji-Nakabayashi-Takano (MNT) curves_, following the procedure described in [\[KT07\]](/references/Karabina Teske 2007 --- On prime-order elliptic curves with embedding degrees k = 3,4, and 6.pdf). The module contains two files:
+This module provides functionality to construct _Miyaji-Nakabayashi-Takano (MNT) curves_, following the procedure described in [\[KT07\]](/references/Karabina%20Teske%202007%20---%20On%20prime-order%20elliptic%20curves%20with%20embedding%20degrees%20k%20%3D%203%2C4%2C%20and%206.pdf). The module contains two files:
 
 * `mnt_curves.py`, which contains the algorithm to construct MNT curves;
 

--- a/ecfactory/mnt_cycles/readme.md
+++ b/ecfactory/mnt_cycles/readme.md
@@ -4,7 +4,7 @@ MNT Cycles
 Overview
 --------
 
-This module provides functionality to construct (pairing-friendly) elliptic curve cycles (of length 2) using MNT curves, following the procedure described in [\[KT07\]](/references/Karabina Teske 2007 --- On prime-order elliptic curves with embedding degrees k = 3,4, and 6.pdf) and [\[BCTV14\]](https://eprint.iacr.org/2014/595). The module contains two files:
+This module provides functionality to construct (pairing-friendly) elliptic curve cycles (of length 2) using MNT curves, following the procedure described in [\[KT07\]](/references/Karabina%20Teske%202007%20---%20On%20prime-order%20elliptic%20curves%20with%20embedding%20degrees%20k%20%3D%203%2C4%2C%20and%206.pdf) and [\[BCTV14\]](https://eprint.iacr.org/2014/595). The module contains two files:
 
 * `mnt_cycles.py`, which contains the algorithm to construct MNT cycles;
 

--- a/ecfactory/pell_equation_solver/readme.md
+++ b/ecfactory/pell_equation_solver/readme.md
@@ -4,7 +4,7 @@ Pell Equation Solver
 Overview
 --------
 
-This module implements an algorithm to solve generalized Pell equations, following the procedure described in [\[KT07\]](/references/Karabina Teske 2007 --- On prime-order elliptic curves with embedding degrees k = 3,4, and 6.pdf). This module contains two files:
+This module implements an algorithm to solve generalized Pell equations, following the procedure described in [\[KT07\]](/references/Karabina%20Teske%202007%20---%20On%20prime-order%20elliptic%20curves%20with%20embedding%20degrees%20k%20%3D%203%2C4%2C%20and%206.pdf). This module contains two files:
 
 * `pell_equation_solver.py`, which contains the algorithm to solve Pell equations;
 


### PR DESCRIPTION
It appears that GitHub has some formatting requirement of the Markdown URL that prevents the correct rendering of the link. This PR fixes this.