### PR TITLE
Make installation pip compatible

### DIFF
--- a/ecfactory/__init__.py
+++ b/ecfactory/__init__.py
@@ -1,10 +1,9 @@
-import utils
-import bn_curves
-import cocks_pinch
-import complex_multiplication
-import dupont_enge_morain
-import ec_chain
-import mnt_curves
-import mnt_cycles
-import pell_equation_solver
-
+import ecfactory.utils
+import ecfactory.bn_curves
+import ecfactory.cocks_pinch
+import ecfactory.complex_multiplication
+import ecfactory.dupont_enge_morain
+import ecfactory.ec_chain
+import ecfactory.mnt_curves
+import ecfactory.mnt_cycles
+import ecfactory.pell_equation_solver

--- a/ecfactory/bn_curves/__init__.py
+++ b/ecfactory/bn_curves/__init__.py
@@ -1,1 +1,1 @@
-from bn_curves import make_curve
+from .bn_curves import make_curve

--- a/ecfactory/cocks_pinch/__init__.py
+++ b/ecfactory/cocks_pinch/__init__.py
@@ -1,1 +1,1 @@
-from cocks_pinch import find_element_of_order, method, run, gen_params_from_bits, gen_params_from_r, test_promise
+from .cocks_pinch import find_element_of_order, method, run, gen_params_from_bits, gen_params_from_r, test_promise

--- a/ecfactory/complex_multiplication/__init__.py
+++ b/ecfactory/complex_multiplication/__init__.py
@@ -1,1 +1,1 @@
-from complex_multiplication import make_curve, small_A_twist, small_B_twist, test_curve
+from .complex_multiplication import make_curve, small_A_twist, small_B_twist, test_curve

--- a/ecfactory/dupont_enge_morain/__init__.py
+++ b/ecfactory/dupont_enge_morain/__init__.py
@@ -1,1 +1,1 @@
-from dupont_enge_morain import method, run
+from .dupont_enge_morain import method, run

--- a/ecfactory/ec_chain/__init__.py
+++ b/ecfactory/ec_chain/__init__.py
@@ -1,1 +1,1 @@
-from ec_chain import make_chain, make_chain_from_bn, new_chain, is_chain
+from .ec_chain import make_chain, make_chain_from_bn, new_chain, is_chain

--- a/ecfactory/mnt_curves/__init__.py
+++ b/ecfactory/mnt_curves/__init__.py
@@ -1,1 +1,1 @@
-from mnt_curves import make_curve
+from .mnt_curves import make_curve

--- a/ecfactory/mnt_cycles/__init__.py
+++ b/ecfactory/mnt_cycles/__init__.py
@@ -1,1 +1,1 @@
-from mnt_cycles import make_cycle
+from .mnt_cycles import make_cycle

--- a/ecfactory/pell_equation_solver/__init__.py
+++ b/ecfactory/pell_equation_solver/__init__.py
@@ -1,1 +1,1 @@
-from pell_equation_solver import pell_solve
+from .pell_equation_solver import pell_solve

--- a/ecfactory/utils/__init__.py
+++ b/ecfactory/utils/__init__.py
@@ -1,1 +1,1 @@
-from utils import is_valid_curve, filter_decorator, is_suitable_curve, is_suitable_q, is_suitable_r, print_curve, curve_to_string
+from .utils import is_valid_curve, filter_decorator, is_suitable_curve, is_suitable_q, is_suitable_r, print_curve, curve_to_string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "ecfactory"
+version = "0.1.0"
+description = "A SageMath Library for Constructing Elliptic Curves"
+authors = ["See AUTHORS file"]
+license = "MIT"
+readme = "readme.md"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,14 @@ From the tuple (_q_,_t_,_r_,_k_,_D_), the curve equation can be found using the 
 Requirements
 ------------
 
-The library requires a working [SageMath](http://www.sagemath.org) installation, and has been tested on SageMath version 6.8 and 7.2.
+The library requires a working [SageMath](http://www.sagemath.org) installation, and has been tested on SageMath version 6.8, 7.2 and 9.7.
 
 Installation
 -----------
 
-To install, add the library to the SAGE\_PATH environment variable:
+To install, use sage pip:
 
-	$ export SAGE_PATH="path/to/library/:$SAGE_PATH"
+	$ git clone https://github.com/scipr-lab/ecfactory.git && cd ecfactory && sage -pip install .
 	
 To import and use the library, write
 


### PR DESCRIPTION
Installing things to `SAGEPATH` directly is not good practice, and as far as I can tell, doesn't even work for my version 9.7 of SageMath. This is a simple change that allows for retaining all old methods but with a much cleaner installation. Updated README as well.